### PR TITLE
1. EEG-level feature export. 2. New features loadable, elapsed, extract_datasetinfo2. 3. Notch filter. 4. Clear_results

### DIFF
--- a/ctap/src/core/CTAP_check_file_loadable.m
+++ b/ctap/src/core/CTAP_check_file_loadable.m
@@ -1,0 +1,84 @@
+function [EEG, Cfg] = CTAP_check_file_loadable(~, Cfg)
+%CTAP_check_file_loadable  - check if file is loadable
+%
+% Description:
+%   Saves results into Cfg.env.paths.featuresRoot/loadable.
+%
+% Syntax:
+%   [Cfg] = CTAP_check_file_loadable(~, Cfg);
+%
+% Description:
+%   Saves results into Cfg.env.paths.featuresRoot/loadable.
+%
+% Syntax:
+%   [Cfg] = CTAP_check_file_loadable(~, Cfg)
+%
+% Inputs:
+%   Cfg         struct, CTAP configuration structure
+%   Cfg.ctap.load_data:
+%   .type   string, Data type, default: '' which uses filename extension as
+%           the data type. Use .type='neurone' if MC.physiodata contains
+%           NeurOne data folders instead of traditional files. 
+%
+% Outputs:
+%   Cfg         struct, Cfg struct is updated by parameters,values actually used
+%
+% Notes: 
+%
+% See also: CTAP_load_data() %
+% Copyright(c) 2017 :
+% Jan Brogger (jan@brogger.no)
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%Return a dummy EEG object
+EEG = eeg_emptyset();
+%% Set optional arguments
+if isfield(Cfg, 'measurement')
+    Arg = Cfg.measurement;
+    Arg.type = ''; %by default guesses file type from MC.physiodata file extension
+else
+    error('CTAP_check_file_loadable:no_measurement', 'Cfg.measurement MUST exist!');
+end
+
+% Override defaults with user parameters
+if isfield(Cfg.ctap, 'load_data')
+    Arg = joinstruct(Arg, Cfg.ctap.load_data);
+end
+
+loadable = 0;
+extns = {'.set', '.bdf', '.edf', '.gdf', '.vhdr', '.eeg', '.vpd', ...
+         '.xml', '.e'};
+file = file_loadable(Arg.physiodata, extns);
+
+if ~file.load
+    loadable = 0;
+else    
+    loadable = 1;
+end
+
+INFO = gather_measurement_metadata(Cfg.subject, Cfg.measurement);
+
+savepath = fullfile(Cfg.env.paths.featuresRoot,'loadable');
+if ~isdir(savepath)
+    mkdir(savepath); 
+end
+savename = sprintf('%s_loadable.mat', Cfg.measurement.casename);
+save(fullfile(savepath,savename), 'INFO', 'loadable');
+
+
+%% ERROR/REPORT
+res = struct;
+res.file = Arg.physiodata;
+
+Arg = joinstruct(Arg, res);
+Cfg.ctap.load_data = Arg;
+
+msg = myReport({'Checked file loadability' Arg.physiodata}, Cfg.env.logFile);
+
+EEG = add_CTAP(EEG, Cfg);
+
+EEG.CTAP.history(end+1) = create_CTAP_history_entry(msg, mfilename, Arg);

--- a/ctap/src/core/CTAP_check_file_loadable.m
+++ b/ctap/src/core/CTAP_check_file_loadable.m
@@ -36,6 +36,7 @@ function [EEG, Cfg] = CTAP_check_file_loadable(~, Cfg)
 
 %Return a dummy EEG object
 EEG = eeg_emptyset();
+
 %% Set optional arguments
 if isfield(Cfg, 'measurement')
     Arg = Cfg.measurement;

--- a/ctap/src/core/CTAP_clear_results.m
+++ b/ctap/src/core/CTAP_clear_results.m
@@ -1,0 +1,52 @@
+function CTAP_clear_results(Cfg)
+%CTAP_clear_results - Clear results
+%
+% Description:
+%   Removes intermediate data, logs, crashlogs, features, etc.
+%
+% Syntax:
+%   CTAP_clear_results(Cfg);
+%
+% Inputs:
+%   Cfg         struct, CTAP configuration structure
+%   Cfg.ctap.load_chanlocs:
+%
+% Outputs: None
+%
+%
+% Copyright(c) 2017 FIOH:
+% Jan Brogger (jan@brogger.no)
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+    root = dir(Cfg.env.paths.analysisRoot);
+    for i = 1:length(root)
+        if strcmp(root(i).name,'.')==0 && strcmp(root(i).name,'..')==0
+            if ~root(i).isdir
+                delete(fullfile(root(i).folder, root(i).name));
+            else
+                files = dir(fullfile(root(i).folder, root(i).name));            
+                for j = 1:length(files)
+                    if strcmp(files(j).name,'.')==0 && strcmp(files(j).name,'..')==0
+                        if ~files(j).isdir
+                            delete(fullfile(files(j).folder, files(j).name));
+                        else
+                            files2 = dir(fullfile(files(j).folder, files(j).name));            
+                            for k = 1:length(files2)
+                                if strcmp(files2(k).name,'.')==0 && strcmp(files2(k).name,'..')==0
+                                    if ~files2(k).isdir
+                                        delete(fullfile(files2(k).folder, files2(k).name));
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end        
+            end
+        end
+    end
+end    

--- a/ctap/src/core/CTAP_clear_results.m
+++ b/ctap/src/core/CTAP_clear_results.m
@@ -31,11 +31,20 @@ function deletefilesandfolders(root)
     rootDir = dir(root);
     for i = 1:length(rootDir)
         if strcmp(rootDir(i).name,'.')==0 && strcmp(rootDir(i).name,'..')==0
-            if rootDir(i).isdir
-                deletefilesandfolders(fullfile(rootDir(i).folder, rootDir(i).name));
-                rmdir(fullfile(rootDir(i).folder, rootDir(i).name));
+            if rootDir(i).isdir                                    
+                dir2delete = fullfile(rootDir(i).folder, rootDir(i).name);
+                deletefilesandfolders(dir2delete);
+                try                     
+                    rmdir(dir2delete);
+                catch
+                    warning(['Couldn''t rmdir ' dir2delete]);
+                end
             else
-                delete(fullfile(rootDir(i).folder, rootDir(i).name));                                               
+                try 
+                    file2delete = fullfile(rootDir(i).folder, rootDir(i).name);                    delete(file2delete);
+                catch
+                    warning(['Couldn''t delete' file2delete]);
+                end
             end
         end
     end

--- a/ctap/src/core/CTAP_clear_results.m
+++ b/ctap/src/core/CTAP_clear_results.m
@@ -8,10 +8,12 @@ function CTAP_clear_results(Cfg)
 %   CTAP_clear_results(Cfg);
 %
 % Inputs:
-%   Cfg         struct, CTAP configuration structure
-%   Cfg.ctap.load_chanlocs:
+%   Cfg  : CTAP configuration structure, must contain this field:
+%   Cfg.env.paths.analysisRoot  : the path to clear results from
 %
 % Outputs: None
+%
+% Effect: Deletes all files and folders in analysisRoot and below
 %
 %
 % Copyright(c) 2017 FIOH:
@@ -22,40 +24,19 @@ function CTAP_clear_results(Cfg)
 % Please see the file LICENSE for details.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+    deletefilesandfolders(Cfg.env.paths.analysisRoot);    
+end    
 
-    root = dir(Cfg.env.paths.analysisRoot);
-    for i = 1:length(root)
-        if strcmp(root(i).name,'.')==0 && strcmp(root(i).name,'..')==0
-            if ~root(i).isdir
-                delete(fullfile(root(i).folder, root(i).name));
+function deletefilesandfolders(root)
+    rootDir = dir(root);
+    for i = 1:length(rootDir)
+        if strcmp(rootDir(i).name,'.')==0 && strcmp(rootDir(i).name,'..')==0
+            if rootDir(i).isdir
+                deletefilesandfolders(fullfile(rootDir(i).folder, rootDir(i).name));
+                rmdir(fullfile(rootDir(i).folder, rootDir(i).name));
             else
-                files = dir(fullfile(root(i).folder, root(i).name));            
-                for j = 1:length(files)
-                    if strcmp(files(j).name,'.')==0 && strcmp(files(j).name,'..')==0
-                        if ~files(j).isdir
-                            delete(fullfile(files(j).folder, files(j).name));
-                        else
-                            files2 = dir(fullfile(files(j).folder, files(j).name));            
-                            for k = 1:length(files2)
-                                if strcmp(files2(k).name,'.')==0 && strcmp(files2(k).name,'..')==0
-                                    if ~files2(k).isdir
-                                        delete(fullfile(files2(k).folder, files2(k).name));
-                                    else
-                                        files3 = dir(fullfile(files2(k).folder, files2(k).name));            
-                                        for l = 1:length(files3)
-                                            if strcmp(files3(l).name,'.')==0 && strcmp(files3(l).name,'..')==0
-                                                if ~files3(l).isdir
-                                                    delete(fullfile(files3(l).folder, files3(l).name));                                               
-                                                end
-                                            end
-                                        end
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end        
+                delete(fullfile(rootDir(i).folder, rootDir(i).name));                                               
             end
         end
     end
-end    
+end

--- a/ctap/src/core/CTAP_clear_results.m
+++ b/ctap/src/core/CTAP_clear_results.m
@@ -40,6 +40,15 @@ function CTAP_clear_results(Cfg)
                                 if strcmp(files2(k).name,'.')==0 && strcmp(files2(k).name,'..')==0
                                     if ~files2(k).isdir
                                         delete(fullfile(files2(k).folder, files2(k).name));
+                                    else
+                                        files3 = dir(fullfile(files2(k).folder, files2(k).name));            
+                                        for l = 1:length(files3)
+                                            if strcmp(files3(l).name,'.')==0 && strcmp(files3(l).name,'..')==0
+                                                if ~files3(l).isdir
+                                                    delete(fullfile(files3(l).folder, files3(l).name));                                               
+                                                end
+                                            end
+                                        end
                                     end
                                 end
                             end

--- a/ctap/src/core/CTAP_clock_start.m
+++ b/ctap/src/core/CTAP_clock_start.m
@@ -1,0 +1,47 @@
+function [EEG, Cfg] = CTAP_clock_start(EEG, Cfg)
+%CTAP_clock_start  - starts processing timer
+%
+% Description:
+%   Starts a clock
+%
+% Syntax:
+%   [EEG, Cfg] = CTAP_compute_psd(EEG, Cfg);
+%
+% Inputs:
+%   EEG         struct, EEGLAB structure
+%
+% Outputs:
+%   EEG         struct, EEGLAB structure modified by this function
+%   Cfg         struct, Cfg struct is updated by parameters,values actually used
+%
+% Notes: 
+%
+% See also: CTAP_clock_stop() %
+% Copyright(c) 2017 :
+% Jan Brogger (jan@brogger.no)
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Set optional arguments
+Arg.clockstart = [];
+
+% Override defaults with user parameters
+if isfield(Cfg, 'elapsed')
+    Arg = joinstruct(Arg, Cfg.elapsed);
+end
+
+%% ERROR/REPORT
+res = struct;
+res.clockstart = datetime('now');
+
+Arg = joinstruct(Arg, res);
+Cfg.elapsed = Arg;
+
+msg = myReport({'Started clock' Arg.clockstart}, Cfg.env.logFile);
+
+EEG = add_CTAP(EEG, Cfg);
+
+EEG.CTAP.history(end+1) = create_CTAP_history_entry(msg, mfilename, Arg);

--- a/ctap/src/core/CTAP_clock_stop.m
+++ b/ctap/src/core/CTAP_clock_stop.m
@@ -1,0 +1,68 @@
+function [EEG, Cfg] = CTAP_clock_stop(EEG, Cfg)
+%CTAP_clock_stop  - stops clock and outputs elapsed time as feature
+%
+%
+% Syntax:
+%   [Cfg] = CTAP_clock_stop(~, Cfg);
+%
+% Description:
+%   Saves elapsed time since last call of CTAP_clock_start
+%   into Cfg.env.paths.featuresRoot/elapsed.
+%
+% Syntax:
+%   [Cfg] = CTAP_check_file_loadable(~, Cfg)
+%
+% Inputs:
+%   Cfg         struct, CTAP configuration structure
+%   Cfg.ctap.load_data:
+%   .type   string, Data type, default: '' which uses filename extension as
+%           the data type. Use .type='neurone' if MC.physiodata contains
+%           NeurOne data folders instead of traditional files. 
+%
+% Outputs:
+%   Cfg         struct, Cfg struct is updated by parameters,values actually used
+%
+% Notes: 
+%
+% See also: CTAP_clock_stop() %
+% Copyright(c) 2017 :
+% Jan Brogger (jan@brogger.no)
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Set optional arguments
+Arg.elapsed = [];
+
+% Override defaults with user parameters
+if isfield(Cfg, 'elapsed')
+    Arg = joinstruct(Arg, Cfg.elapsed);
+end
+
+elapsed = seconds(time(between(Cfg.elapsed.clockstart, datetime('now'))));
+
+
+[INFO SEGMENT] = gather_measurement_metadata(Cfg.subject, Cfg.measurement);
+
+savepath = fullfile(Cfg.env.paths.featuresRoot,'elapsed');
+if ~isdir(savepath)
+    mkdir(savepath); 
+end
+savename = sprintf('%s_elapsed.mat', Cfg.measurement.casename);
+save(fullfile(savepath,savename), 'INFO', 'SEGMENT', 'elapsed');
+
+
+%% ERROR/REPORT
+res = struct;
+res.elapsed = elapsed;
+
+Arg = joinstruct(Arg, res);
+Cfg.elapsed = Arg;
+
+msg = myReport({'Elapsed ' Arg.elapsed}, Cfg.env.logFile);
+
+EEG = add_CTAP(EEG, Cfg);
+
+EEG.CTAP.history(end+1) = create_CTAP_history_entry(msg, mfilename, Arg);

--- a/ctap/src/core/CTAP_extract_dataset_info2.m
+++ b/ctap/src/core/CTAP_extract_dataset_info2.m
@@ -1,0 +1,62 @@
+function [EEG, Cfg] = CTAP_extract_dataset_info2(EEG, Cfg)
+%CTAP_extract_dataset_info2  - extract info about EEG file
+%                              as features
+%
+% Description:
+%   Saves results into Cfg.env.paths.featuresRoot/dataset_info2.
+%
+% Syntax:
+%   [Cfg] = CTAP_extract_dataset_info2(~, Cfg);
+%
+% Inputs:
+%   Cfg         struct, CTAP configuration structure
+%
+% Outputs:
+%   Cfg         struct, Cfg struct is updated by parameters,values actually used
+%
+% Notes: 
+%
+% See also: CTAP_extract_dataset_info() %
+% Copyright(c) 2017 :
+% Jan Brogger (jan@brogger.no)
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% create Arg and assign any defaults to be chosen at the CTAP_ level
+Arg = struct;
+% check and assign the defined parameters to structure Arg, for brevity
+if isfield(Cfg.ctap, 'extract_dataset_info2')
+    Arg = joinstruct(Arg, Cfg.ctap.extract_dataset_info2);%override with user params
+end
+
+[INFO SEGMENT] = gather_measurement_metadata(Cfg.subject, Cfg.measurement);
+
+dataset_info2 = struct();
+dataset_info2.srate = EEG.srate;
+dataset_info2.samples = size(EEG.data,2);
+dataset_info2.lengthSeconds = dataset_info2.samples/dataset_info2.srate;
+dataset_info2.nbchan = EEG.nbchan;
+dataset_info2.startDateTime = EEG.startDateTime;
+dataset_info2.segments = length(find(strcmp({EEG.event.type}, 'boundary')))+1;
+
+savepath = fullfile(Cfg.env.paths.featuresRoot,'dataset_info2');
+if ~isdir(savepath)
+    mkdir(savepath); 
+end
+savename = sprintf('%s_dataset_info2.mat', Cfg.measurement.casename);
+save(fullfile(savepath,savename), 'INFO', 'SEGMENT', 'dataset_info2');
+
+
+%% ERROR/REPORT
+Cfg.ctap.extract_dataset_info2 = Arg;
+msg = myReport(sprintf('Dataset info 2 stored for measurement %s.',...
+    EEG.CTAP.measurement.casename), Cfg.env.logFile);
+%create an entry to the history struct, with 
+%   1. informative message, 
+%   2. function filename
+%   3. %the complete parameter set from the function call, for reference
+EEG.CTAP.history(end+1) = create_CTAP_history_entry(msg, mfilename, Arg);
+

--- a/ctap/src/core/CTAP_fir_notchfilter.m
+++ b/ctap/src/core/CTAP_fir_notchfilter.m
@@ -1,0 +1,121 @@
+function [EEG, Cfg] = CTAP_fir_notchfilter(EEG, Cfg)
+%CTAP_fir_notchfilter - FIR notch filter data using firfilt plugin (pop_eegfiltnew.m)
+%
+% Description:
+%   A wrapper to use pop_eegfiltnew.m in CTAP.
+%   Note at least one cut-off frequency needs to be set.
+%   If only ''locutoff'' set -> high-pass filter
+%   if only ''hicutoff'' set -> low-pass filter
+%   If both set -> band pass filter
+%
+% Syntax:
+%   [EEG, Cfg] = CTAP_fir_notchfilter(EEG, Cfg);
+%
+% Inputs:
+%   EEG         struct, EEGLAB structure
+%   Cfg         struct, CTAP configuration structure
+%
+%   Cfg.ctap.fir_filter:
+%   .lowcutoff  [1,1] numeric, Low end of the pass band in Hz, default: []
+%   .highcutoff [1,1] numeric, High end of the pass band in Hz, default: []
+%   .filtorder [1,1] integer, Filter order, default: [] i.e. order set by
+%                             the filtering function
+%   .revfilt [1,1] integer, Invert filter from bandpass to notch filter?,
+%                           allowed values: {0,1}, default: 1 (notch)
+%   .plotfreqz [1,1] integer, Plot filter's frequency and phase response?,
+%                             allowed values: {0, 1},
+%                             default: 0 (does not plot)
+%   .minphase [1,1] numeric, Make the filter scalar boolean minimum-phase 
+%                            converted causal filter,
+%                            allowed values: {0,1}, default: 0
+%
+% Outputs:
+%   EEG         EEGLAB struct, FIR filtered data 
+%   Cfg         struct, Cfg struct is updated by parameters,
+%               values actually used
+%
+% Notes: 
+%
+% See also: pop_eegfiltnew.m 
+%
+% Copyright(c) 2017 
+% Jan Brogger jan@brogger.no 
+% Based on CTAP_fir_filter
+%
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Set optional arguments
+% Default values as in pop_eegfiltnew()
+Arg.locutoff = [];
+Arg.hicutoff = [];
+Arg.filtorder = [];
+Arg.revfilt = 1;
+Arg.plotfreqz = 0;
+Arg.minphase = 0;
+
+
+% Override defaults with user parameters
+if isfield(Cfg.ctap, 'fir_notchfilter')
+    Arg = joinstruct(Arg, Cfg.ctap.fir_filter); %override w user params
+end
+
+% Check that the user has set some cutoff (i.e. not running on defaults)
+if isempty(Arg.locutoff) && isempty(Arg.hicutoff)
+   error('CTAP_fir_filter:inputError', ...
+       'At least one of the notch filter cut off frequencies ''locutoff'' or ''hicutoff'' needs to be set. See pop_eegfiltnew.m for details.'); 
+end
+
+
+%% ASSIST
+if Cfg.grfx.on
+    EEG0 = EEG;
+end
+
+
+%% CORE
+[EEG, ~, b] = pop_eegfiltnew(EEG, Arg.locutoff, Arg.hicutoff, Arg.filtorder,...
+                               Arg.revfilt, 0, Arg.plotfreqz, Arg.minphase);
+
+
+
+%% ERROR/REPORT
+Arg.a = []; %these are empty for FIR
+Arg.b = b;
+Cfg.ctap.filter_data = Arg;
+
+msg = sprintf('FIR notch filtered data using pop_eegfiltnew(): %s', EEG.setname); 
+myReport(msg, Cfg.env.logFile);
+EEG.CTAP.history(end+1) = create_CTAP_history_entry(msg, mfilename, Arg);
+
+if Cfg.grfx.on
+    
+    if isempty(Arg.hicutoff)
+        xlim_arr = [0, 50];
+    else
+        xlim_arr = [0 Arg.hicutoff + 15];
+    end
+    
+    % Make figure: PSD comparison plot and step response
+    fg = plot_filter_response(EEG, EEG0, b, 'xlimits', xlim_arr);
+
+    % Save
+    qcfile = fullfile(get_savepath(Cfg, mfilename, 'qc'),...
+          sprintf('filter_notch_effects_%s.png', EEG.CTAP.measurement.casename));
+    saveas(fg, qcfile)
+    close(fg);
+    
+    
+    % firfilt plugin default plots
+    fg = figure('Visible','off');
+    plotfresp(b, [], [], EEG.srate);
+    qcfile = fullfile(get_savepath(Cfg, mfilename, 'qc'),...
+          sprintf('filter_notch_properties_%s.png', EEG.CTAP.measurement.casename));
+    saveas(fg, qcfile)
+    close(fg);
+    
+    
+    
+end

--- a/ctap/src/core/export_features_CTAP2.m
+++ b/ctap/src/core/export_features_CTAP2.m
@@ -1,0 +1,202 @@
+function CTAP_export_features2(id, featureIDArr, measFilt, MC, Cfg)
+%CTAP_export_features2 - Export of CTAP study-level features into a text file
+%
+% Description:
+%   Generates a list of result files based on 'featureIDArr' and
+%   'measFilt'. Reads data from these files, formats it and saves the
+%   result into a text file. 
+%   Note: only simple primitive data are exported. Arrays, such as 
+%   features from segments, are not exported.
+%
+%   Compared to export_features_CTAP, this function can export
+%   whole-EEG features (one feature per EEG). The original
+%   export_features_CTAP can only export features per epoch.
+%
+% Syntax:
+%   export_features_CTAP2(id, featureIDArr, measFilt, MC, Cfg);
+%
+% Inputs:
+%   id              string, Result csv file name (without ".csv")
+%   featureIDArr    [1,M] cell of strings, Names of the feature collections
+%                   to export. Available values are the subfolder names in 
+%                   Cfg.env.paths.featuresRoot.
+%   measFilt        struct, Filter that defines a subset of measurements to
+%                   load. struct([]) loads all available measurements.
+%   MC              struct, Subject and measurement metadata struct
+%   Cfg             struct, CTAP configuration structure
+%
+% Outputs:
+%   Saves output as an CSV file in Cfg.env.paths.exportRoot.
+%
+% Assumptions:
+%
+% References:
+%
+% Example:
+%   CTAP_export_features2('myResultSet', {'dataset_info2'}, struct([]), MC, Cfg);
+%
+% Notes:
+%
+% Based on: export_features_CTAP
+% See also: export_features_CTAP
+%
+% Version History:
+% 1.06.2014 Created (Jussi Korpela, FIOH)
+% 1.0.2017 Created (Jan Brogger)
+%
+% Copyright(c) 2017:
+% Jan Brogger (jan@brogger.no)
+
+% This code is released under the MIT License
+% http://opensource.org/licenses/mit-license.php
+% Please see the file LICENSE for details.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    %% Initialize
+    % Create directory (if needed)
+    if ~isdir(Cfg.env.paths.exportRoot)
+        mkdir(Cfg.env.paths.exportRoot);
+    end
+
+    %% Create an array of source files
+    disp(sprintf('Exporting features from: %s', Cfg.env.paths.featuresRoot));
+    sourcefile_arr = export_features_CTAP2_getfeaturefiles(id, featureIDArr, measFilt, MC, Cfg);
+
+    savefile = fullfile(Cfg.env.paths.exportRoot, sprintf('%s.txt',id));
+    
+	labels = {'subjectnr' 'subject' 'casename', ...
+              'feature' 'feature2' 'value'};
+    format_array = {'%d', '%s', '%s', '%s', '%s', '%020.5f'};
+    
+    [pathstr, name, saveExt] = fileparts(savefile);
+    
+    j = 0;
+    for i=1:numel(sourcefile_arr)
+        result = export_features_CTAP2_onefile(sourcefile_arr{i});        
+        for k=1:numel(result)
+            if ~isempty(result{k})
+                j = j +1;
+                if j == 1
+                    % Write header and data
+                    cell2txtfile(savefile, labels, result{k}, format_array,...
+                        'delimiter', '\t',...
+                        'writemode', 'wt',...
+                        'allownans', 'false');
+                else
+                    % Append
+                    cell2txtfile(savefile, {}, result{k}, format_array,...
+                        'delimiter', '\t',...
+                        'writemode', 'at',...
+                        'allownans', 'false');
+                end
+            end
+        end
+       
+    end 
+       
+end
+
+function sourcefile_arr = export_features_CTAP2_getfeaturefiles(id, featureIDArr, measFilt, MC, Cfg)
+    sourcefile_arr={};
+    if isempty(measFilt)
+        % Load all measurements available
+        for i= 1:length(featureIDArr)
+            i_feat = featureIDArr{i};
+            i_srcPath = fullfile(Cfg.env.paths.featuresRoot,i_feat);
+            i_fileArr = dir(fullfile(i_srcPath, sprintf('*_%s.mat',i_feat)));
+
+            sourcefile_arr = vertcat(sourcefile_arr,...
+                        strcat(i_srcPath, filesep, {i_fileArr.name}'));
+        end%i    
+    else
+        % Load all measurement that match measFilt
+        MeasurementSub = struct_filter(MC.measurement, measFilt);
+
+        for i= 1:length(featureIDArr)
+            i_feat = featureIDArr{i};
+            for k = 1:length(MeasurementSub)
+                k_file = fullfile(Cfg.env.paths.featuresRoot, i_feat, ...
+                         sprintf('%s_%s.mat', MeasurementSub(k).casename,i_feat));
+
+                if exist(k_file, 'file')
+                    sourcefile_arr = vertcat(sourcefile_arr, k_file); %#ok<*AGROW>
+                end
+            end %k
+        end%i
+    end%if
+end
+
+function result = export_features_CTAP2_onefile(sourcefile)
+	result = cell(1);
+    resultCount = 0;
+    [pathstr, filename, ext] = fileparts(sourcefile);
+    msg = ['dataexport: Processing file ', [filename,ext], '...'];
+    disp(msg);
+    
+    % Load data
+    M = load(sourcefile);    
+    % Get the fields of the data that are not part of the CTAP/ATTK data format
+    % (i.e. not INFO or SEGMENT)
+    thisFileFieldNames = fieldnames(M);    
+    thisFileValueFields = thisFileFieldNames(...
+        ~(strcmp(thisFileFieldNames, 'INFO') | strcmp(thisFileFieldNames, 'SEGMENT')));    
+        
+    subjectnr = M.INFO.subjectnr;
+    subject = M.INFO.subject;
+    casename = M.INFO.casename;
+    
+    for j=1:length(thisFileValueFields)  
+        % Get the fields of the data that are not part of the CTAP/ATTK 
+        %data format(i.e. not labels, units, paramters, sublevels)        
+        thisStruct = eval(char(strcat('M.' , thisFileValueFields(j))));
+        if isa(thisStruct,'double')            
+            resultCount = resultCount+1;
+            result{resultCount} = {subjectnr, ...
+                          subject, ...
+                          casename, ...
+                          char(thisFileValueFields(j)), ...
+                          char(thisFileValueFields(j)), ...
+                          thisStruct};
+        elseif isstruct(thisStruct)
+            thisStructFieldNames = fieldnames(thisStruct);
+            thisStructValueFields = ...
+                thisStructFieldNames( ...
+                ~( ...
+                    ismember(thisStructFieldNames, 'labels') | ...
+                    ismember(thisStructFieldNames, 'units') | ...
+                    ismember(thisStructFieldNames, 'parameters') |...
+                    ismember(thisStructFieldNames, 'sublevels') ...
+                 ) ...
+                );        
+           for k=1:length(thisStructValueFields)
+               thisStructValueField = thisStructValueFields(k);
+               thisStructValueFieldType = eval(char(...
+                  strcat('class(M.',thisFileValueFields(j),'.',thisStructValueField,')')...
+                ));
+              if strcmp(thisStructValueFieldType,'double') || ...
+                 strcmp(thisStructValueFieldType,'datetime') || ...
+                 strcmp(thisStructValueFieldType,'char')
+                 actualValue = eval(char(...
+                     strcat('M.',thisFileValueFields(j),'.',thisStructValueField) ...
+                 ));
+                  %Skip arrays, only do primitives
+                  if numel(actualValue)==1
+                     if strcmp(thisStructValueFieldType,'datetime')
+                         actualValue = datenum(actualValue);
+                     end
+                     resultCount = resultCount+1;
+                     result{resultCount} = {subjectnr, ...
+                          subject, ...
+                          casename, ...
+                          char(thisFileValueFields(j)), ...
+                          char(thisStructValueField), ...
+                          actualValue};
+                  end
+              end
+           end
+        else
+            error('Unknown field type');
+       end
+    end    
+        
+end

--- a/ctap/src/pipeline/ctap_auto_config.m
+++ b/ctap/src/pipeline/ctap_auto_config.m
@@ -71,25 +71,36 @@ if isfield(Cfg.env.paths, 'ctapRoot')
     end
     [~,~,~] = mkdir(Cfg.env.paths.analysisRoot);
     
-    
-    Cfg.env.paths.featuresRoot = fullfile(...
-        Cfg.env.paths.analysisRoot,'features');
+    if ~isfield(Cfg.env.paths,'featuresRoot')
+        Cfg.env.paths.featuresRoot = fullfile(...
+            Cfg.env.paths.analysisRoot,'features');
+    end
 
-    Cfg.env.paths.exportRoot = fullfile(...
-        Cfg.env.paths.analysisRoot,'export');
+    if ~isfield(Cfg.env.paths,'export')
+        Cfg.env.paths.exportRoot = fullfile(...
+            Cfg.env.paths.analysisRoot,'export');
+    end
 
-    Cfg.env.paths.qualityControlRoot = fullfile(...
-        Cfg.env.paths.analysisRoot,'quality_control');
+    if ~isfield(Cfg.env.paths,'quality_control')
+        Cfg.env.paths.qualityControlRoot = fullfile(...
+            Cfg.env.paths.analysisRoot,'quality_control');
+    end
     
-    Cfg.env.paths.logRoot = fullfile(...
-        Cfg.env.paths.analysisRoot,'logs');
+    if ~isfield(Cfg.env.paths,'logRoot')
+        Cfg.env.paths.logRoot = fullfile(...
+            Cfg.env.paths.analysisRoot,'logs');
+    end        
     
-    Cfg.env.paths.crashLogRoot = fullfile(...
-        Cfg.env.paths.ctapRoot,'logs');
+    if ~isfield(Cfg.env.paths,'crashLogRoot')
+        Cfg.env.paths.crashLogRoot = fullfile(...
+            Cfg.env.paths.ctapRoot,'logs');
+    end
     
     % Log Files
-    Cfg.env.logFile = fullfile(Cfg.env.paths.logRoot,...
+    if ~isfield(Cfg.env,'logFile')
+        Cfg.env.logFile = fullfile(Cfg.env.paths.logRoot,...
                                sprintf('runlog_%s.txt',datestr(now, 30)) );
+    end                           
 
 else
    error('ctap_auto_config:cfgFieldMissing',...

--- a/ctap/src/pipeline/gather_measurement_metadata.m
+++ b/ctap/src/pipeline/gather_measurement_metadata.m
@@ -1,4 +1,4 @@
-function MeasMeta = gather_measurement_metadata(Subject, Measurement, varargin)
+function [MeasMeta WholeFileFakeSegment] = gather_measurement_metadata(Subject, Measurement, varargin)
 %GATHER_MEASUREMENT_METADATA - Collect information from MC
 %
 % Description:
@@ -17,7 +17,11 @@ function MeasMeta = gather_measurement_metadata(Subject, Measurement, varargin)
 %   Keyword     Type, description, values
 %
 % Outputs:
-%   'MeasMeta'      ??, ??
+%   'MeasMeta'      ??, ?? (output this as INFO struct in the ATTK format)
+%   WholeFileFakeSegment (output this as SEGMENT struct in the ATTK format,
+%                         which creates a 'segment' that is actually the
+%                         whole file.
+%   
 %
 % Assumptions:
 %
@@ -81,4 +85,14 @@ if ~isempty(Arg.measurementFields)
             fprintf(2,['gather_measurement_metadata: field ''',i_field_name,''' not found in Subject.\n']);
         end
     end
+end
+
+% Create a SEGMENT structure that is in fact a segment for the whole file
+WholeFileFakeSegment = struct();
+WholeFileFakeSegment.labels = {'timestamp'  'duration'  'label'  'latency'  'value'};
+WholeFileFakeSegment.units = {'yyyymmddTHHMMSS' 'samples' 'n/a' 'n/a' 'n/a'};
+if ~exist('EEG','var')
+    WholeFileFakeSegment.data = {datestr(now(),'yyyymmddTHHMMSS') 0 'NA' 0 'NA'};
+else
+    WholeFileFakeSegment.data = {datestr(EEG.startDateTime,'yyyymmddTHHMMSS') EEG.pnts 'NA' 1 'NA'};
 end


### PR DESCRIPTION
Added new CTAP_export_features2 to export study-level features (not just segments)
Added new feature CTAP_check_file_loadable. Creates ~projectroot/features/loadable
Added new feature for timing: CTAP_clock_start and CTAP_clock_stop . Creates ~projectroot/features/elapsed
Added new feature CTAP_extract_dataset_info2 - EEG file level descriptives
Added new filter CTAP_fir_notchfilter (easier to document and use than two calls to CTAP_fir_filter)
Added utility function CTAP_clear_results - deletes all logs, results, features (for use during development)
Modified ctap_auto_config so that it doesn't overwrite path specifications (if they are set before call to ctap_auto_config)
Modified gather_measurement_metadata to output a segment for the whole segment, for use with study level features. Does not impact existing code.
